### PR TITLE
Delete only resque-alive redis keys on teardown

### DIFF
--- a/lib/resque/plugins/alive.rb
+++ b/lib/resque/plugins/alive.rb
@@ -133,7 +133,6 @@ module Resque
         "#{config.registered_instance_key}::#{hostname}"
       end
 
-
       def self.register_instance(instance_name)
         redis.set(
           instance_name,
@@ -146,7 +145,12 @@ module Resque
         # Delete any pending jobs for this instance
         logger.info(shutdown_info)
         purge_pending_jobs
+        remove_resque_alive_data
+      end
+
+      def self.remove_resque_alive_data
         redis.del(current_instance_register_key)
+        redis.del(current_liveness_key)
       end
 
       def self.purge_pending_jobs

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   config.before do
     ResqueSpec.reset!
 
-    Resque::Plugins::Alive.redis.flushall
+    Resque::Plugins::Alive.remove_resque_alive_data
     Resque::Plugins::Alive.config.set_defaults
   end
 end


### PR DESCRIPTION
Summary
-------

Fix spec teardown to cleanup only resque-alive related redis keys.

Context
-------

The spec_helper attempts to isolate example context by calling `flushall` in between each example execution. This works fine if `resque-alive`'s spec suite is the only thing writing to the redis instance, but could be catastrophic if the redis instance is shared with other projects, or used for other purposes on the development host. This prevents causing mayhem in such cases, by instead limiting the cleanup to only resque-alive related keys.  